### PR TITLE
Add TypeScript definition

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1,0 +1,1 @@
+export default function lowercaseKeys(input: object): object;

--- a/index.test-d.ts
+++ b/index.test-d.ts
@@ -1,4 +1,4 @@
 import {expectType} from 'tsd-check';
 import lowercaseKeys from '.';
 
-expectType<object>(lowercaseKeys({Test:true}));
+expectType<object>(lowercaseKeys({Test: true}));

--- a/index.test-d.ts
+++ b/index.test-d.ts
@@ -1,0 +1,4 @@
+import {expectType} from 'tsd-check';
+import lowercaseKeys from '.';
+
+expectType<object>(lowercaseKeys({Test:true}));

--- a/package.json
+++ b/package.json
@@ -13,9 +13,10 @@
 		"node": ">=6"
 	},
 	"scripts": {
-		"test": "xo && ava"
+		"test": "xo && ava && tsd-check"
 	},
 	"files": [
+		"index.d.ts",
 		"index.js"
 	],
 	"keywords": [
@@ -31,6 +32,7 @@
 	],
 	"devDependencies": {
 		"ava": "*",
+		"tsd-check": "^0.3.0",
 		"xo": "*"
 	}
 }

--- a/package.json
+++ b/package.json
@@ -16,8 +16,8 @@
 		"test": "xo && ava && tsd-check"
 	},
 	"files": [
-		"index.d.ts",
-		"index.js"
+		"index.js",
+		"index.d.ts"
 	],
 	"keywords": [
 		"object",


### PR DESCRIPTION
The tests are failing because `Object.entries` isn't available on node 6.

If you'd like I can send another PR to either change the tests to run for now 8, & 10.
Or, I ca send a PR to switch to `Object.keys` instead.

Cheers